### PR TITLE
added power support arch ppc64le on yml file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 ---
+arch:
+    - amd64
+    - ppc64le
 language: bash
 sudo: required
 


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.
please  check and close this component.